### PR TITLE
Sanitize X-MMe-Client-Info to avoid Apple's Xcode-based GSA block

### DIFF
--- a/src/AnisetteDataManager.cpp
+++ b/src/AnisetteDataManager.cpp
@@ -13,6 +13,30 @@
 
 #define odslog(msg) { std::stringstream ss; ss << msg << std::endl; OutputDebugStringA(ss.str().c_str()); }
 
+// Since ~2026-09, Apple's GSA edge (gsa.apple.com/grandslam/GsService2) rejects with an
+// immediate HTTP 503 any request whose "X-MMe-Client-Info" header contains the substring
+// "com.apple.dt.Xcode" - independent of version, User-Agent, or connection reuse. This was
+// confirmed here with a direct curl repro (with vs. without the substring: 503 vs 401, i.e.
+// actually reaching the auth service), matching altstoreio/AltStore PR #1790's findings.
+// Our anisette server (ani.sidestore.io) reports a client-info string containing exactly
+// that substring, so we sanitize it once here, at the single point where anisette data
+// enters this program, before it's ever used to build a request header.
+// See: https://github.com/altstoreio/AltStore/pull/1790
+static std::string SanitizeClientInfo(std::string clientInfo)
+{
+	const std::string needle = "com.apple.dt.Xcode";
+	const std::string replacement = "com.apple.akd";
+
+	size_t pos = 0;
+	while ((pos = clientInfo.find(needle, pos)) != std::string::npos)
+	{
+		clientInfo.replace(pos, needle.length(), replacement);
+		pos += replacement.length();
+	}
+
+	return clientInfo;
+}
+
 AnisetteDataManager* AnisetteDataManager::_instance = nullptr;
 
 AnisetteDataManager* AnisetteDataManager::instance()
@@ -133,7 +157,7 @@ std::shared_ptr<AnisetteData> AnisetteDataManager::FetchAnisetteData()
 					std::atoi(jsonVal.at("X-Apple-I-MD-RINFO").as_string().c_str()),
 					jsonVal.at("X-Mme-Device-Id").as_string(),
 					jsonVal.at("X-Apple-I-SRL-NO").as_string(),
-					jsonVal.at("X-MMe-Client-Info").as_string(),
+					SanitizeClientInfo(jsonVal.at("X-MMe-Client-Info").as_string()),
 					tv,
 					jsonVal.at("X-Apple-Locale").as_string(),
 					jsonVal.at("X-Apple-I-TimeZone").as_string());


### PR DESCRIPTION
## Problem

Since ~early September 2026, every Apple ID sign-in through this project fails
with an HTTP 503 from `gsa.apple.com/grandslam/GsService2`, before Apple's
authentication logic is ever reached.

## Root cause

Credit for the actual root cause goes to
[altstoreio/AltStore#1790](https://github.com/altstoreio/AltStore/pull/1790):
Apple's GSA edge rejects any request whose `X-MMe-Client-Info` header
contains the substring `com.apple.dt.Xcode`, independent of version,
User-Agent, or connection reuse. That PR fixed it for AltStore's own (Swift,
macOS) anisette code.

This project doesn't share that code — it fetches anisette data as JSON from
an external anisette server (`AnisetteDataManager::FetchAnisetteData`), and
the `X-MMe-Client-Info` value such servers commonly return still identifies
as Xcode, tripping the same block. I confirmed this independently with two
otherwise-identical requests directly against the live endpoint:

```
X-MMe-Client-Info containing "com.apple.dt.Xcode" -> 503 (blocked at the edge)
X-MMe-Client-Info containing "com.apple.akd"      -> 401 (reaches the real service)
```

## Fix

Adds a small `SanitizeClientInfo()` helper in `AnisetteDataManager.cpp` that
rewrites that one substring at the single point anisette data enters this
program (right when the anisette server's JSON response is parsed), so every
downstream call site in AltSign that later forwards
`anisetteData->deviceDescription()` as the `X-MMe-Client-Info` header (there
are four of them) is covered without needing to touch vendored AltSign code
at all.

This is intentionally scoped to just this one issue. It does *not* include
the separate, already-known GrandSlam "reuse the same connection for 3
requests" fix ([AltSign#52](https://github.com/rileytestut/AltSign/pull/52) /
[#47](https://github.com/rileytestut/AltSign/pull/47)), since that lives in
the vendored `AltSign` submodule rather than this project's own code, and
would need a different approach (e.g. extending
`rewrite_altsign_source.py`) to contribute cleanly. Happy to follow up with
that separately if useful.

## Testing

Verified end-to-end against a real iPhone and a real Apple ID over several
days of testing (no device or account details included here). Before this
change, GrandSlam requests failed with HTTP 503 on the very first request.
After it, requests reach Apple's authentication service normally (structured
200/401 responses instead of an opaque 503 HTML page), and a full
sign-in + IPA install completes successfully.

Not tested on 32-bit ARM/x86 builds, only x86_64.